### PR TITLE
feat: :sparkles: add impure function pointer variant in BuildinProcedure

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 pub trait IEnvironment<R: RealNumberInternalTrait>: std::fmt::Debug + Clone + PartialEq {
-    fn new() -> Self
+    fn new() -> Rc<RefCell<Self>>
     where
         Self: Sized;
     fn define(&mut self, name: String, value: Value<R, Self>)
@@ -39,11 +39,11 @@ pub struct StandardEnv<R: RealNumberInternalTrait> {
 impl<R: RealNumberInternalTrait> IEnvironment<R> for StandardEnv<R> {
     // type DefinitionCollection = std::collections::hash_map::Iter<'a， String, Value<R, StandardEnv<R>>>;
 
-    fn new() -> Self {
-        Self {
+    fn new() -> Rc<RefCell<Self>> {
+        Rc::new(RefCell::new(Self {
             parent: None,
             definitions: scheme::base::base_library::<R, StandardEnv<R>>(),
-        }
+        }))
     }
     fn new_child(parent: Rc<RefCell<StandardEnv<R>>>) -> Self {
         Self {

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 pub trait IEnvironment<R: RealNumberInternalTrait>: std::fmt::Debug + Clone + PartialEq {
-    fn new() -> Rc<RefCell<Self>>
+    fn new() -> Self
     where
         Self: Sized;
     fn define(&mut self, name: String, value: Value<R, Self>)
@@ -39,11 +39,11 @@ pub struct StandardEnv<R: RealNumberInternalTrait> {
 impl<R: RealNumberInternalTrait> IEnvironment<R> for StandardEnv<R> {
     // type DefinitionCollection = std::collections::hash_map::Iter<'a， String, Value<R, StandardEnv<R>>>;
 
-    fn new() -> Rc<RefCell<Self>> {
-        Rc::new(RefCell::new(Self {
+    fn new() -> Self {
+        Self {
             parent: None,
             definitions: scheme::base::base_library::<R, StandardEnv<R>>(),
-        }))
+        }
     }
     fn new_child(parent: Rc<RefCell<StandardEnv<R>>>) -> Self {
         Self {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -185,7 +185,7 @@ impl<R: RealNumberInternalTrait, E: IEnvironment<R>> BuildinProcedurePointer<R, 
     pub fn eval(&self, args: ArgVec<R, E>) -> Result<Value<R, E>> {
         match &self {
             Self::Pure(pointer) => pointer(args),
-            Self::Impure(pointer, closure) => pointer(args, closure.clone()),
+            Self::Impure(pointer, env) => pointer(args, env.clone()),
         }
     }
 }

--- a/src/interpreter/scheme/base.rs
+++ b/src/interpreter/scheme/base.rs
@@ -187,11 +187,11 @@ pub fn base_library<'a, R: RealNumberInternalTrait, E: IEnvironment<R>>(
         ($ident:tt, $parameter_length:expr, $function:tt) => {
             (
                 $ident.to_string(),
-                Value::Procedure(Procedure::Buildin(BuildinProcedure {
-                    name: $ident,
-                    parameter_length: $parameter_length,
-                    pointer: $function,
-                })),
+                Value::Procedure(Procedure::new_buildin_pure(
+                    $ident,
+                    $parameter_length,
+                    $function,
+                )),
             )
         };
     }


### PR DESCRIPTION
Some buildin procedure do need some side effect for environment(for example, bind a texture slot, in you-know-what), so we need to add env to function pointer.