### PR TITLE
New buildin procedure vector-set!, refactor all buildin procedures.

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -472,12 +472,57 @@ impl<T> Object<T> {
             Object::Mutable(t) => Box::new(t.borrow()),
         }
     }
-    pub fn as_mut<'a>(&'a self) -> Option<RefMut<'a, T>> {
+    pub fn as_mut<'a>(&'a self) -> Result<RefMut<'a, T>> {
         match self {
-            Object::Immutable(_) => None,
-            Object::Mutable(t) => Some(t.borrow_mut()),
+            Object::Immutable(_) => Err(SchemeError {
+                location: None,
+                category: ErrorType::Logic,
+                message: "expect a mutable object, get a immutable object!".to_string(),
+            }),
+            Object::Mutable(t) => Ok(t.borrow_mut()),
         }
     }
+}
+
+macro_rules! match_expect_type {
+    ($value:expr, $type:pat => $inner: expr, $type_name:expr) => {
+        match $value {
+            $type => Ok($inner),
+            v => Err(SchemeError {
+                location: None,
+                category: ErrorType::Logic,
+                message: format!("expect a {}, got {}", $type_name, v),
+            }),
+        }
+    };
+}
+#[test]
+fn macro_match_expect_type() {
+    assert_eq!(
+        match_expect_type!(
+            Value::<f32, StandardEnv<_>>::Number(Number::Integer(5)),
+            Value::Number(Number::Integer(i)) => i, "integer"
+        ),
+        Ok(5)
+    );
+    assert_eq!(
+        match_expect_type!(
+            Value::<f32, StandardEnv<_>>::Number(Number::Integer(1)),
+            Value::Number(Number::Integer(i)) => i + 3, "integer"
+        ),
+        Ok(4)
+    );
+    assert_eq!(
+        match_expect_type!(
+            Value::<f32, StandardEnv<_>>::Number(Number::Integer(5)),
+            Value::String(s) => s, "string"
+        ),
+        Err(SchemeError {
+            location: None,
+            category: ErrorType::Logic,
+            message: "expect a string, got 5".to_string(),
+        })
+    );
 }
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value<R: RealNumberInternalTrait, E: IEnvironment<R>> {
@@ -490,6 +535,20 @@ pub enum Value<R: RealNumberInternalTrait, E: IEnvironment<R>> {
     Vector(Object<Vec<Value<R, E>>>),
     List(LinkedList<Value<R, E>>),
     Void,
+}
+
+impl<R: RealNumberInternalTrait, E: IEnvironment<R>> Value<R, E> {
+    pub fn expect_number(self) -> Result<Number<R>> {
+        match_expect_type!(self, Value::Number(number) => number, "number")
+    }
+
+    pub fn expect_integer(self) -> Result<i32> {
+        match_expect_type!(self, Value::Number(Number::Integer(i)) => i, "integer")
+    }
+
+    pub fn expect_vector(self) -> Result<Object<Vec<Value<R, E>>>> {
+        match_expect_type!(self, Value::Vector(vector) => vector, "vector")
+    }
 }
 
 impl<R: RealNumberInternalTrait, E: IEnvironment<R>> fmt::Display for Value<R, E> {

--- a/src/interpreter/scheme/base.rs
+++ b/src/interpreter/scheme/base.rs
@@ -222,7 +222,7 @@ fn vector<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let vector: Vec<Value<R, E>> = arguments.into_iter().collect();
-    Ok(Value::Vector(Object::new_mutable(vector)))
+    Ok(Value::Vector(ValueReference::new_mutable(vector)))
 }
 
 fn vector_ref<R: RealNumberInternalTrait, E: IEnvironment<R>>(
@@ -240,7 +240,7 @@ fn vector_ref<R: RealNumberInternalTrait, E: IEnvironment<R>>(
 
 #[test]
 fn buildin_vector_ref() {
-    let vector: Value<f32, StandardEnv<_>> = Value::Vector(Object::Immutable(vec![
+    let vector: Value<f32, StandardEnv<_>> = Value::Vector(ValueReference::new_immutable(vec![
         Value::Number(Number::Integer(5)),
         Value::String("foo".to_string()),
         Value::Number(Number::Rational(5, 3)),
@@ -291,7 +291,7 @@ fn vector_set<R: RealNumberInternalTrait, E: IEnvironment<R>>(
 
 #[test]
 fn buildin_vector_set() -> Result<()> {
-    let vector: Value<f32, StandardEnv<_>> = Value::Vector(Object::new_mutable(vec![
+    let vector: Value<f32, StandardEnv<_>> = Value::Vector(ValueReference::new_mutable(vec![
         Value::Number(Number::Integer(5)),
         Value::String("foo".to_string()),
         Value::Number(Number::Rational(5, 3)),
@@ -305,7 +305,7 @@ fn buildin_vector_set() -> Result<()> {
         assert_eq!(vector_set(arguments), Ok(Value::Void));
         assert_eq!(
             vector,
-            Value::Vector(Object::new_mutable(vec![
+            Value::Vector(ValueReference::new_mutable(vec![
                 Value::Number(Number::Real(3.14)),
                 Value::String("foo".to_string()),
                 Value::Number(Number::Rational(5, 3)),
@@ -321,7 +321,7 @@ fn buildin_vector_set() -> Result<()> {
         assert_eq!(vector_set(arguments), Ok(Value::Void));
         assert_eq!(
             vector,
-            Value::Vector(Object::new_mutable(vec![
+            Value::Vector(ValueReference::new_mutable(vec![
                 Value::Number(Number::Real(3.14)),
                 Value::Number(Number::Integer(5)),
                 Value::Number(Number::Rational(5, 3)),
@@ -337,7 +337,7 @@ fn buildin_vector_set() -> Result<()> {
         assert_eq!(vector_set(arguments), Ok(Value::Void));
         assert_eq!(
             vector,
-            Value::Vector(Object::new_mutable(vec![
+            Value::Vector(ValueReference::new_mutable(vec![
                 Value::Number(Number::Real(3.14)),
                 Value::Number(Number::Integer(5)),
                 Value::String("bar".to_string()),

--- a/src/interpreter/scheme/base.rs
+++ b/src/interpreter/scheme/base.rs
@@ -8,70 +8,168 @@ fn add<R: RealNumberInternalTrait, E: IEnvironment<R>>(
 ) -> Result<Value<R, E>> {
     arguments
         .into_iter()
-        .try_fold(Value::Number(Number::Integer(0)), |a, b| match (a, b) {
-            (Value::Number(num1), Value::Number(num2)) => Ok(Value::Number(num1 + num2)),
-            o => logic_error!("expect a number, got {}", o.1),
-        })
+        .try_fold(Number::Integer(0), |a, b| Ok(a + b.expect_number()?))
+        .map(|num| Value::Number(num))
+}
+
+#[test]
+fn buildin_add() {
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![];
+        assert_eq!(add(arguments), Ok(Value::Number(Number::Integer(0))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![Value::Number(Number::Integer(2))];
+        assert_eq!(add(arguments), Ok(Value::Number(Number::Integer(2))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(3)),
+        ];
+        assert_eq!(add(arguments), Ok(Value::Number(Number::Integer(5))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(3)),
+            Value::Number(Number::Integer(4)),
+        ];
+        assert_eq!(add(arguments), Ok(Value::Number(Number::Integer(9))));
+    }
 }
 
 fn sub<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let mut iter = arguments.into_iter();
-    let init = match iter.next().unwrap() {
-        Value::Number(first_num) => match iter.next() {
-            Some(second) => match second {
-                Value::Number(second_num) => Value::Number(first_num - second_num),
-                o => logic_error!("expect a number, got {}", o),
-            },
-            None => Value::Number(Number::Integer(0) - first_num),
-        },
-        o => logic_error!("expect a number, got {}", o),
+    let first = iter.next().unwrap().expect_number()?;
+    let init = match iter.next() {
+        Some(value) => first - value.expect_number()?,
+        None => Number::Integer(0) - first,
     };
-    iter.try_fold(init, |a, b| match (a, b) {
-        (Value::Number(num1), Value::Number(num2)) => Ok(Value::Number(num1 - num2)),
-        o => logic_error!("expect a number, got {}", o.1),
-    })
+    iter.try_fold(init, |a, b| Ok(a - b.expect_number()?))
+        .map(|num| Value::Number(num))
+}
+
+#[test]
+fn buildin_sub() {
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![Value::Number(Number::Integer(2))];
+        assert_eq!(sub(arguments), Ok(Value::Number(Number::Integer(-2))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(3)),
+        ];
+        assert_eq!(sub(arguments), Ok(Value::Number(Number::Integer(-1))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(3)),
+            Value::Number(Number::Integer(4)),
+        ];
+        assert_eq!(sub(arguments), Ok(Value::Number(Number::Integer(-5))));
+    }
 }
 
 fn mul<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
-    let mut iter = arguments.into_iter();
-    iter.try_fold(Value::Number(Number::Integer(1)), |a, b| match (a, b) {
-        (Value::Number(num1), Value::Number(num2)) => Ok(Value::Number(num1 * num2)),
-        o => logic_error!("expect a number, got {}", o.1),
-    })
+    arguments
+        .into_iter()
+        .try_fold(Number::Integer(1), |a, b| Ok(a * b.expect_number()?))
+        .map(|num| Value::Number(num))
+}
+
+#[test]
+fn buildin_mul() {
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![];
+        assert_eq!(mul(arguments), Ok(Value::Number(Number::Integer(1))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![Value::Number(Number::Integer(2))];
+        assert_eq!(mul(arguments), Ok(Value::Number(Number::Integer(2))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(3)),
+        ];
+        assert_eq!(mul(arguments), Ok(Value::Number(Number::Integer(6))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(3)),
+            Value::Number(Number::Integer(4)),
+        ];
+        assert_eq!(mul(arguments), Ok(Value::Number(Number::Integer(24))));
+    }
 }
 
 fn div<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let mut iter = arguments.into_iter();
-    let init = match iter.next().unwrap() {
-        Value::Number(first_num) => match iter.next() {
-            Some(second) => match second {
-                Value::Number(second_num) => Value::Number((first_num / second_num)?),
-                o => logic_error!("expect a number, got {}", o),
-            },
-            None => Value::Number((Number::Integer(1) / first_num)?),
-        },
-        o => logic_error!("expect a number, got {}", o),
+    let first = iter.next().unwrap().expect_number()?;
+    let init = match iter.next() {
+        Some(value) => (first / value.expect_number()?)?,
+        None => (Number::Integer(1) / first)?,
     };
-    iter.try_fold(init, |a, b| match (a, b) {
-        (Value::Number(num1), Value::Number(num2)) => Ok(Value::Number((num1 / num2)?)),
-        o => logic_error!("expect a number, got {}", o.1),
-    })
+    iter.try_fold(init, |a, b| Ok((a / b.expect_number()?)?))
+        .map(|num| Value::Number(num))
 }
+
+#[test]
+fn buildin_div() {
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![Value::Number(Number::Integer(2))];
+        assert_eq!(div(arguments), Ok(Value::Number(Number::Real(0.5))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(8)),
+        ];
+        assert_eq!(div(arguments), Ok(Value::Number(Number::Real(0.25))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(8)),
+            Value::Number(Number::Real(0.125)),
+        ];
+        assert_eq!(
+            div(arguments),
+            Ok(Value::<f32, _>::Number(Number::Real(2.)))
+        );
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(0)),
+        ];
+        assert_eq!(
+            div(arguments),
+            Err(SchemeError {
+                location: None,
+                category: ErrorType::Logic,
+                message: "division by exact zero".to_string(),
+            })
+        );
+    }
+}
+
 macro_rules! numeric_one_argument {
     ($name:tt, $func:tt$(, $err_handle:tt)?) => {
         fn $func<R: RealNumberInternalTrait, E: IEnvironment<R>>(
             arguments: impl IntoIterator<Item = Value<R, E>>,
         ) -> Result<Value<R, E>> {
-            match arguments.into_iter().next().unwrap() {
-                Value::Number(number) => Ok(Value::Number(number.$func()$($err_handle)?)),
-                other => logic_error!("{} requires a number, got {:?}", $name, other),
-            }
+            Ok(Value::Number(arguments.into_iter().next().unwrap().expect_number()?.$func()$($err_handle)?))
         }
     };
 }
@@ -89,17 +187,6 @@ fn buildin_numeric_one() {
             vec![Value::Number(Number::Rational(-49, 3))];
         assert_eq!(floor(arguments), Ok(Value::Number(Number::Integer(-17))));
     }
-    {
-        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![Value::String("foo".to_string())];
-        assert_eq!(
-            sqrt(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "sqrt requires a number, got String(\"foo\")".to_string(),
-            })
-        );
-    }
 }
 
 macro_rules! numeric_two_arguments {
@@ -108,14 +195,8 @@ macro_rules! numeric_two_arguments {
             arguments: impl IntoIterator<Item = Value<R, E>>,
         ) -> Result<Value<R, E>> {
             let mut iter = arguments.into_iter();
-            let lhs = match iter.next().unwrap() {
-                Value::Number(number) => number,
-                _ => logic_error!("expect a number!"),
-            };
-            let rhs = match iter.next().unwrap() {
-                Value::Number(number) => number,
-                _ => logic_error!("expect a number!"),
-            };
+            let lhs = iter.next().unwrap().expect_number()?;
+            let rhs = iter.next().unwrap().expect_number()?;
             Ok(Value::Number(lhs.$func(rhs)$($err_handle)?))
         }
     };
@@ -136,20 +217,6 @@ fn buildin_numeric_two() {
             Ok(Value::Number(Number::Integer(2)))
         );
     }
-    {
-        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
-            Value::String("foo".to_string()),
-            Value::String("bar".to_string()),
-        ];
-        assert_eq!(
-            floor_quotient(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "expect a number!".to_string(),
-            })
-        );
-    }
 }
 fn vector<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
@@ -162,16 +229,13 @@ fn vector_ref<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let mut iter = arguments.into_iter();
-    match iter.next().unwrap() {
-        Value::Vector(vector) => match iter.next().unwrap() {
-            Value::Number(Number::Integer(i)) => match vector.as_ref().get(i as usize) {
-                Some(value) => Ok(value.clone()),
-                None => logic_error!("vector index out of bound"),
-            },
-            _ => logic_error!("expect a integer!"),
-        },
-        _ => logic_error!("expect a vector!"),
-    }
+    let vector = iter.next().unwrap().expect_vector()?;
+    let k = iter.next().unwrap().expect_integer()?;
+    let r = match vector.as_ref().get(k as usize) {
+        Some(value) => Ok(value.clone()),
+        None => logic_error!("vector index out of bound"),
+    };
+    r
 }
 
 #[test]
@@ -207,57 +271,24 @@ fn buildin_vector_ref() {
             })
         );
     }
-    {
-        let arguments = vec![vector.clone(), Value::Number(Number::Real(1.5))];
-        assert_eq!(
-            vector_ref(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "expect a integer!".to_string(),
-            })
-        );
-    }
-    {
-        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
-            Value::Number(Number::Integer(1)),
-            Value::Number(Number::Integer(1)),
-        ];
-        assert_eq!(
-            vector_ref(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "expect a vector!".to_string(),
-            })
-        );
-    }
 }
 
 fn vector_set<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let mut iter = arguments.into_iter();
-    let vector = match iter.next().unwrap() {
-        Value::Vector(vector) => vector,
-        _ => logic_error!("expect a vector!"),
-    };
-    let k = match iter.next().unwrap() {
-        Value::Number(Number::Integer(i)) => i,
-        _ => logic_error!("expect a integer!"),
-    };
+    let vector = iter.next().unwrap().expect_vector()?;
+    let k = iter.next().unwrap().expect_integer()?;
     let obj = iter.next().unwrap();
-    match vector.as_mut() {
-        None => logic_error!("expect a mutable vector, get a immutable vector!"),
-        Some(mut vector) => match vector.get_mut(k as usize) {
-            None => logic_error!("vector index out of bound"),
-            Some(value) => {
-                *value = obj;
-            }
-        },
+    match vector.as_mut()?.get_mut(k as usize) {
+        None => logic_error!("vector index out of bound"),
+        Some(value) => {
+            *value = obj;
+        }
     }
     Ok(Value::Void)
 }
+
 #[test]
 fn buildin_vector_set() -> Result<()> {
     let vector: Value<f32, StandardEnv<_>> = Value::Vector(Object::new_mutable(vec![
@@ -328,36 +359,6 @@ fn buildin_vector_set() -> Result<()> {
             })
         );
     }
-    {
-        let arguments = vec![
-            vector.clone(),
-            Value::Number(Number::Rational(31, 5)),
-            Value::Number(Number::Integer(5)),
-        ];
-        assert_eq!(
-            vector_set(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "expect a integer!".to_string(),
-            })
-        );
-    }
-    {
-        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
-            Value::Number(Number::Integer(1)),
-            Value::Number(Number::Integer(1)),
-            Value::Number(Number::Integer(5)),
-        ];
-        assert_eq!(
-            vector_set(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "expect a vector!".to_string(),
-            })
-        );
-    }
     Ok(())
 }
 
@@ -384,20 +385,16 @@ macro_rules! comparision {
             match iter.next() {
                 None => Ok(Value::Boolean(true)),
                 Some(first) => {
-                            let mut last = first;
-                            for current in iter {
-                                match (last, current) {
-                                    (Value::Number(a), Value::Number(b)) => {
-                                        if !(a $operator b) {
-                                            return Ok(Value::Boolean(false));
-                                        }
-                                        last = Value::Number(b);
-                                    }
-                                    _ => logic_error!("{} comparision can only between numbers!", stringify!($operator)),
-                                }
-                            }
-                            Ok(Value::Boolean(true))
+                    let mut last_num = first.expect_number()?;
+                    for current in iter {
+                        let current_num = current.expect_number()?;
+                        if !(last_num $operator current_num) {
+                            return Ok(Value::Boolean(false));
                         }
+                        last_num = current_num;
+                    }
+                    Ok(Value::Boolean(true))
+                }
 
             }
         }
@@ -410,32 +407,104 @@ comparision!(greater_equal, >=);
 comparision!(less, <);
 comparision!(less_equal, <=);
 
+#[test]
+fn buildin_greater() {
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![];
+        assert_eq!(greater(arguments), Ok(Value::Boolean(true)));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![Value::Number(Number::Integer(2))];
+        assert_eq!(greater(arguments), Ok(Value::Boolean(true)));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(4)),
+            Value::Number(Number::Integer(2)),
+        ];
+        assert_eq!(greater(arguments), Ok(Value::Boolean(true)));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(4)),
+            Value::Number(Number::Integer(8)),
+        ];
+        assert_eq!(greater(arguments), Ok(Value::Boolean(false)));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(4)),
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(1)),
+        ];
+        assert_eq!(greater(arguments), Ok(Value::Boolean(true)));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(4)),
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(2)),
+        ];
+        assert_eq!(greater(arguments), Ok(Value::Boolean(false)));
+    }
+}
+
 macro_rules! first_of_order {
     ($name:tt, $cmp:tt) => {
         fn $name<R: RealNumberInternalTrait, E: IEnvironment<R>>(
                         arguments: impl IntoIterator<Item = Value<R, E>>
         ) -> Result<Value<R, E>> {
             let mut iter = arguments.into_iter();
-            match iter.next().unwrap() {
-                Value::Number(num) => {
-                    iter.try_fold(Value::Number(num), |a, b| match (a, b) {
-                        (Value::Number(num1), Value::Number(num2)) => {
-                            Ok(Value::Number(match num1 $cmp num2 {
-                                true => upcast_oprands((num1, num2)).lhs(),
-                                false => upcast_oprands((num1, num2)).rhs(),
-                            }))
-                        }
-                        o => logic_error!("expect a number, got {}", o.1),
-                    })
-                },
-                o => logic_error!("expect a number, got {}", o),
-                }
+            let init = iter.next().unwrap().expect_number()?;
+            iter.try_fold(init, |a, b_value| {
+                let b = b_value.expect_number()?;
+                let oprand = upcast_oprands((a, b));
+                Ok(if a $cmp b {oprand.lhs()} else {oprand.rhs()})
+            }).map(|num| Value::Number(num))
             }
         }
 }
 
 first_of_order!(max, >);
 first_of_order!(min, <);
+
+#[test]
+fn buildin_min() {
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![Value::Number(Number::Integer(2))];
+        assert_eq!(min(arguments), Ok(Value::Number(Number::Integer(2))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(4)),
+            Value::Number(Number::Integer(2)),
+        ];
+        assert_eq!(min(arguments), Ok(Value::Number(Number::Integer(2))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(4)),
+            Value::Number(Number::Integer(8)),
+        ];
+        assert_eq!(min(arguments), Ok(Value::Number(Number::Integer(4))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(4)),
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(1)),
+        ];
+        assert_eq!(min(arguments), Ok(Value::Number(Number::Integer(1))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(4)),
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(2)),
+        ];
+        assert_eq!(greater(arguments), Ok(Value::Boolean(false)));
+    }
+}
 
 pub fn base_library<'a, R: RealNumberInternalTrait, E: IEnvironment<R>>(
 ) -> HashMap<String, Value<R, E>> {

--- a/src/interpreter/scheme/base.rs
+++ b/src/interpreter/scheme/base.rs
@@ -18,18 +18,15 @@ fn sub<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let mut iter = arguments.into_iter();
-    let init = match iter.next() {
-        None => logic_error!("'-' needs at least one argument"),
-        Some(first) => match first {
-            Value::Number(first_num) => match iter.next() {
-                Some(second) => match second {
-                    Value::Number(second_num) => Value::Number(first_num - second_num),
-                    o => logic_error!("expect a number, got {}", o),
-                },
-                None => Value::Number(Number::Integer(0) - first_num),
+    let init = match iter.next().unwrap() {
+        Value::Number(first_num) => match iter.next() {
+            Some(second) => match second {
+                Value::Number(second_num) => Value::Number(first_num - second_num),
+                o => logic_error!("expect a number, got {}", o),
             },
-            o => logic_error!("expect a number, got {}", o),
+            None => Value::Number(Number::Integer(0) - first_num),
         },
+        o => logic_error!("expect a number, got {}", o),
     };
     iter.try_fold(init, |a, b| match (a, b) {
         (Value::Number(num1), Value::Number(num2)) => Ok(Value::Number(num1 - num2)),
@@ -51,18 +48,15 @@ fn div<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let mut iter = arguments.into_iter();
-    let init = match iter.next() {
-        None => logic_error!("'/' needs at least one argument"),
-        Some(first) => match first {
-            Value::Number(first_num) => match iter.next() {
-                Some(second) => match second {
-                    Value::Number(second_num) => Value::Number((first_num / second_num)?),
-                    o => logic_error!("expect a number, got {}", o),
-                },
-                None => Value::Number((Number::Integer(1) / first_num)?),
+    let init = match iter.next().unwrap() {
+        Value::Number(first_num) => match iter.next() {
+            Some(second) => match second {
+                Value::Number(second_num) => Value::Number((first_num / second_num)?),
+                o => logic_error!("expect a number, got {}", o),
             },
-            o => logic_error!("expect a number, got {}", o),
+            None => Value::Number((Number::Integer(1) / first_num)?),
         },
+        o => logic_error!("expect a number, got {}", o),
     };
     iter.try_fold(init, |a, b| match (a, b) {
         (Value::Number(num1), Value::Number(num2)) => Ok(Value::Number((num1 / num2)?)),
@@ -74,10 +68,9 @@ macro_rules! numeric_one_argument {
         fn $func<R: RealNumberInternalTrait, E: IEnvironment<R>>(
             arguments: impl IntoIterator<Item = Value<R, E>>,
         ) -> Result<Value<R, E>> {
-            match arguments.into_iter().next() {
-                Some(Value::Number(number)) => Ok(Value::Number(number.$func()$($err_handle)?)),
-                Some(other) => logic_error!("{} requires a number, got {:?}", $name, other),
-                _ => logic_error!("{} takes exactly one argument", $name),
+            match arguments.into_iter().next().unwrap() {
+                Value::Number(number) => Ok(Value::Number(number.$func()$($err_handle)?)),
+                other => logic_error!("{} requires a number, got {:?}", $name, other),
             }
         }
     };
@@ -107,17 +100,6 @@ fn buildin_numeric_one() {
             })
         );
     }
-    {
-        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![];
-        assert_eq!(
-            floor(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "floor takes exactly one argument".to_string(),
-            })
-        );
-    }
 }
 
 macro_rules! numeric_two_arguments {
@@ -126,15 +108,13 @@ macro_rules! numeric_two_arguments {
             arguments: impl IntoIterator<Item = Value<R, E>>,
         ) -> Result<Value<R, E>> {
             let mut iter = arguments.into_iter();
-            let lhs = match iter.next() {
-                Some(Value::Number(number)) => number,
-                Some(_) => logic_error!("expect a number!"),
-                _ => logic_error!("{} takes exactly two arguments", $name),
+            let lhs = match iter.next().unwrap() {
+                Value::Number(number) => number,
+                _ => logic_error!("expect a number!"),
             };
-            let rhs = match iter.next() {
-                Some(Value::Number(number)) => number,
-                Some(_) => logic_error!("expect a number!"),
-                _ => logic_error!("{} takes exactly two arguments", $name),
+            let rhs = match iter.next().unwrap() {
+                Value::Number(number) => number,
+                _ => logic_error!("expect a number!"),
             };
             Ok(Value::Number(lhs.$func(rhs)$($err_handle)?))
         }
@@ -170,28 +150,6 @@ fn buildin_numeric_two() {
             })
         );
     }
-    {
-        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![Value::Number(Number::Integer(1))];
-        assert_eq!(
-            floor_remainder(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "floor-remainder takes exactly two arguments".to_string(),
-            })
-        );
-    }
-    {
-        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![];
-        assert_eq!(
-            floor_quotient(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "floor-quotient takes exactly two arguments".to_string(),
-            })
-        );
-    }
 }
 fn vector<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
@@ -204,11 +162,9 @@ fn vector_ref<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let mut iter = arguments.into_iter();
-    match iter.next() {
-        None => logic_error!("vector-ref requires exactly two argument"),
-        Some(Value::Vector(vector)) => match iter.next() {
-            None => logic_error!("vector-ref requires exactly two argument"),
-            Some(Value::Number(Number::Integer(i))) => match vector.as_ref().get(i as usize) {
+    match iter.next().unwrap() {
+        Value::Vector(vector) => match iter.next().unwrap() {
+            Value::Number(Number::Integer(i)) => match vector.as_ref().get(i as usize) {
                 Some(value) => Ok(value.clone()),
                 None => logic_error!("vector index out of bound"),
             },
@@ -276,48 +232,21 @@ fn buildin_vector_ref() {
             })
         );
     }
-    {
-        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![];
-        assert_eq!(
-            vector_ref(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "vector-ref requires exactly two argument".to_string(),
-            })
-        );
-    }
-    {
-        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![vector];
-        assert_eq!(
-            vector_ref(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "vector-ref requires exactly two argument".to_string(),
-            })
-        );
-    }
 }
 
 fn vector_set<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let mut iter = arguments.into_iter();
-    let vector = match iter.next() {
-        None => logic_error!("vector-set! requires exactly three argument"),
-        Some(Value::Vector(vector)) => vector,
+    let vector = match iter.next().unwrap() {
+        Value::Vector(vector) => vector,
         _ => logic_error!("expect a vector!"),
     };
-    let k = match iter.next() {
-        None => logic_error!("vector-set! requires exactly three argument"),
-        Some(Value::Number(Number::Integer(i))) => i,
+    let k = match iter.next().unwrap() {
+        Value::Number(Number::Integer(i)) => i,
         _ => logic_error!("expect a integer!"),
     };
-    let obj = match iter.next() {
-        None => logic_error!("vector-set! requires exactly three argument"),
-        Some(value) => value,
-    };
+    let obj = iter.next().unwrap();
     match vector.as_mut() {
         None => logic_error!("expect a mutable vector, get a immutable vector!"),
         Some(mut vector) => match vector.get_mut(k as usize) {
@@ -429,65 +358,21 @@ fn buildin_vector_set() -> Result<()> {
             })
         );
     }
-    {
-        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![];
-        assert_eq!(
-            vector_set(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "vector-set! requires exactly three argument".to_string(),
-            })
-        );
-    }
-    {
-        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![vector.clone()];
-        assert_eq!(
-            vector_set(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "vector-set! requires exactly three argument".to_string(),
-            })
-        );
-    }
-    {
-        let arguments: Vec<Value<f32, StandardEnv<_>>> =
-            vec![vector, Value::Number(Number::Integer(1))];
-        assert_eq!(
-            vector_set(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "vector-set! requires exactly three argument".to_string(),
-            })
-        );
-    }
     Ok(())
 }
 
 fn display<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
-    Ok(match arguments.into_iter().next() {
-        Some(value) => {
-            print!("{}", value);
-            Value::Void
-        }
-        None => logic_error!("display takes exactly one argument"),
-    })
+    print!("{}", arguments.into_iter().next().unwrap());
+    Ok(Value::Void)
 }
 
 fn newline<R: RealNumberInternalTrait, E: IEnvironment<R>>(
-    arguments: impl IntoIterator<Item = Value<R, E>>,
+    _: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
-    Ok(match arguments.into_iter().next() {
-        None => {
-            println!("");
-            Value::<R, E>::Void
-        }
-        _ => logic_error!("display takes exactly one argument"),
-    })
+    println!("");
+    Ok(Value::Void)
 }
 
 macro_rules! comparision {
@@ -531,20 +416,19 @@ macro_rules! first_of_order {
                         arguments: impl IntoIterator<Item = Value<R, E>>
         ) -> Result<Value<R, E>> {
             let mut iter = arguments.into_iter();
-            match iter.next() {
-                None => logic_error!("min requires at least one argument!"),
-                Some(Value::Number(num)) => {
+            match iter.next().unwrap() {
+                Value::Number(num) => {
                     iter.try_fold(Value::Number(num), |a, b| match (a, b) {
-                                (Value::Number(num1), Value::Number(num2)) => {
-                                    Ok(Value::Number(match num1 $cmp num2 {
-                                        true => upcast_oprands((num1, num2)).lhs(),
-                                        false => upcast_oprands((num1, num2)).rhs(),
-                                    }))
-                                }
-                                o => logic_error!("expect a number, got {}", o.1),
-                            })
-                        },
-                Some(o) => logic_error!("expect a number, got {}", o),
+                        (Value::Number(num1), Value::Number(num2)) => {
+                            Ok(Value::Number(match num1 $cmp num2 {
+                                true => upcast_oprands((num1, num2)).lhs(),
+                                false => upcast_oprands((num1, num2)).rhs(),
+                            }))
+                        }
+                        o => logic_error!("expect a number, got {}", o.1),
+                    })
+                },
+                o => logic_error!("expect a number, got {}", o),
                 }
             }
         }
@@ -570,16 +454,16 @@ pub fn base_library<'a, R: RealNumberInternalTrait, E: IEnvironment<R>>(
 
     vec![
         function_mapping!("+", vec![], Some("x".to_string()), add),
-        function_mapping!("-", vec![], Some("x".to_string()), sub),
+        function_mapping!("-", vec!["x1".to_string()], Some("x".to_string()), sub),
         function_mapping!("*", vec![], Some("x".to_string()), mul),
-        function_mapping!("/", vec![], Some("x".to_string()), div),
+        function_mapping!("/", vec!["x1".to_string()], Some("x".to_string()), div),
         function_mapping!("=", vec![], Some("x".to_string()), equals),
         function_mapping!("<", vec![], Some("x".to_string()), less),
         function_mapping!("<=", vec![], Some("x".to_string()), less_equal),
         function_mapping!(">", vec![], Some("x".to_string()), greater),
         function_mapping!(">=", vec![], Some("x".to_string()), greater_equal),
-        function_mapping!("min", vec![], Some("x".to_string()), min),
-        function_mapping!("max", vec![], Some("x".to_string()), max),
+        function_mapping!("min", vec!["x1".to_string()], Some("x".to_string()), min),
+        function_mapping!("max", vec!["x1".to_string()], Some("x".to_string()), max),
         function_mapping!("sqrt", vec!["x".to_string()], None, sqrt),
         function_mapping!("floor", vec!["x".to_string()], None, floor),
         function_mapping!("ceiling", vec!["x".to_string()], None, ceiling),

--- a/src/interpreter/scheme/base.rs
+++ b/src/interpreter/scheme/base.rs
@@ -205,10 +205,9 @@ fn vector_ref<R: RealNumberInternalTrait, E: IEnvironment<R>>(
 ) -> Result<Value<R, E>> {
     let mut iter = arguments.into_iter();
     match iter.next() {
-        None => logic_error!("vector_ref requires exactly two argument"),
+        None => logic_error!("vector-ref requires exactly two argument"),
         Some(Value::Vector(vector)) => match iter.next() {
-            None => logic_error!("vector_ref requires exactly two argument"),
-            Some(Value::Number(Number::Integer(i))) => match vector.get(i as usize) {
+            None => logic_error!("vector-ref requires exactly two argument"),
                 Some(value) => Ok(value.clone()),
                 None => logic_error!("vector index out of bound"),
             },
@@ -283,7 +282,7 @@ fn buildin_vector_ref() {
             Err(SchemeError {
                 location: None,
                 category: ErrorType::Logic,
-                message: "vector_ref requires exactly two argument".to_string(),
+                message: "vector-ref requires exactly two argument".to_string(),
             })
         );
     }
@@ -294,7 +293,7 @@ fn buildin_vector_ref() {
             Err(SchemeError {
                 location: None,
                 category: ErrorType::Logic,
-                message: "vector_ref requires exactly two argument".to_string(),
+                message: "vector-ref requires exactly two argument".to_string(),
             })
         );
     }


### PR DESCRIPTION
* Use Value::expect_xxx to get the expect type of value, simplify the buildin library code
* Add unit test for add, sub, mul, div, greater and min
* Refactor Value::Vector to avoid clone, intro mutability