### PR TITLE
feat: pairs and lists

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,12 +12,12 @@ pub enum ErrorType {
     Logic,
 }
 #[derive(Debug, Clone)]
-pub struct Located<T: PartialEq + Display> {
+pub struct Located<T: PartialEq> {
     pub data: T,
     pub location: Option<[u32; 2]>,
 }
 
-impl<T: PartialEq + Display> Located<T> {
+impl<T: PartialEq> Located<T> {
     pub fn from_data(data: T) -> Self {
         Self {
             data,
@@ -31,7 +31,7 @@ impl<T: PartialEq + Display> Located<T> {
     }
 }
 
-impl<T: PartialEq + Display> PartialEq for Located<T> {
+impl<T: PartialEq> PartialEq for Located<T> {
     fn eq(&self, other: &Self) -> bool {
         self.data == other.data
     }
@@ -42,6 +42,7 @@ impl<T: PartialEq + Display> Display for Located<T> {
         self.data.fmt(f)
     }
 }
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct SchemeError {
     pub category: ErrorType,
@@ -59,6 +60,16 @@ impl Display for SchemeError {
             ErrorType::Logic => write!(f, "error: {}", self.message),
         }
     }
+}
+
+#[cfg(test)]
+pub(crate) fn convert_located<T: PartialEq>(datas: Vec<T>) -> Vec<Located<T>> {
+    datas.into_iter().map(|d| Located::from_data(d)).collect()
+}
+
+#[cfg(test)]
+pub fn l<T: PartialEq>(data: T) -> Located<T> {
+    Located::from_data(data)
 }
 
 macro_rules! invalid_token {

--- a/src/interpreter/pair.rs
+++ b/src/interpreter/pair.rs
@@ -1,0 +1,47 @@
+use std::{fmt::Display, iter::FromIterator};
+
+use super::{RealNumberInternalTrait, Value};
+use crate::environment::IEnvironment;
+
+// r7rs 6.4. Pairs and lists
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Pair<R: RealNumberInternalTrait, E: IEnvironment<R>> {
+    pub car: Value<R, E>,
+    pub cdr: Value<R, E>,
+}
+
+impl<R: RealNumberInternalTrait, E: IEnvironment<R>> Display for Pair<R, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({} ", self.car)?;
+        let mut current_value = &self.cdr;
+        loop {
+            match current_value {
+                Value::Pair(next_pair) => {
+                    write!(f, "{}", next_pair.car)?;
+                    match next_pair.cdr {
+                        Value::EmptyList => (),
+                        _ => write!(f, " ")?,
+                    }
+                    current_value = &next_pair.cdr;
+                }
+                Value::EmptyList => break,
+                other => {
+                    write!(f, ". {}", other)?;
+                    break;
+                }
+            };
+        }
+        write!(f, ")")
+    }
+}
+
+impl<R: RealNumberInternalTrait, E: IEnvironment<R>> FromIterator<Value<R, E>> for Value<R, E> {
+    fn from_iter<I: IntoIterator<Item = Value<R, E>>>(iter: I) -> Self {
+        let mut list = Value::EmptyList;
+        for i in iter {
+            list = Value::Pair(Box::new(Pair { car: i, cdr: list }));
+        }
+        list
+    }
+}

--- a/src/interpreter/scheme/base.rs
+++ b/src/interpreter/scheme/base.rs
@@ -3,6 +3,46 @@ use crate::interpreter::*;
 use crate::parser::ParameterFormals;
 use std::collections::HashMap;
 
+fn car<R: RealNumberInternalTrait, E: IEnvironment<R>>(
+    arguments: impl IntoIterator<Item = Value<R, E>>,
+) -> Result<Value<R, E>> {
+    let mut iter = arguments.into_iter();
+    match iter.next() {
+        Some(Value::Pair(list)) => Ok(list.car.clone()),
+        _ => logic_error!("car target is not a list/pair"),
+    }
+}
+
+fn cdr<R: RealNumberInternalTrait, E: IEnvironment<R>>(
+    arguments: impl IntoIterator<Item = Value<R, E>>,
+) -> Result<Value<R, E>> {
+    let mut iter = arguments.into_iter();
+    match iter.next() {
+        Some(Value::Pair(list)) => Ok(list.cdr.clone()),
+        _ => logic_error!("cdr target is not a list/pair"),
+    }
+}
+
+fn cons<R: RealNumberInternalTrait, E: IEnvironment<R>>(
+    arguments: impl IntoIterator<Item = Value<R, E>>,
+) -> Result<Value<R, E>> {
+    let mut iter = arguments.into_iter();
+    match (iter.next(), iter.next()) {
+        (Some(car), Some(cdr)) => Ok(Value::Pair(Box::new(Pair { car, cdr }))),
+        _ => unreachable!(),
+    }
+}
+
+fn ispair<R: RealNumberInternalTrait, E: IEnvironment<R>>(
+    arguments: impl IntoIterator<Item = Value<R, E>>,
+) -> Result<Value<R, E>> {
+    let arg = arguments.into_iter().next().unwrap();
+    match arg {
+        Value::Pair(_) => Ok(Value::Boolean(true)),
+        _ => Ok(Value::Boolean(false)),
+    }
+}
+
 fn add<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
@@ -403,6 +443,15 @@ pub fn base_library<'a, R: RealNumberInternalTrait, E: IEnvironment<R>>(
     }
 
     vec![
+        function_mapping!("car", vec!["pair".to_string()], None, car),
+        function_mapping!("cdr", vec!["pair".to_string()], None, cdr),
+        function_mapping!(
+            "cons",
+            vec!["car".to_string(), "cdr".to_string()],
+            None,
+            cons
+        ),
+        function_mapping!("pair?", vec!["obj".to_string()], None, ispair),
         function_mapping!("+", vec![], Some("x".to_string()), add),
         function_mapping!("-", vec![], Some("x".to_string()), sub),
         function_mapping!("*", vec![], Some("x".to_string()), mul),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -133,7 +133,15 @@ impl<CharIter: Iterator<Item = char>> Lexer<CharIter> {
                     },
                     None => Ok(None),
                 },
-                '.' => self.percular_identifier(),
+                '.' => match self.peekable_char_stream.peek() {
+                    Some(c) => match c {
+                        ' ' | '\t' | '\n' | '\r' | '(' | ')' | '"' | ';' | '|' => {
+                            Ok(Some(TokenData::Period))
+                        }
+                        _ => self.percular_identifier(),
+                    },
+                    None => Ok(Some(TokenData::Period)),
+                },
                 '+' | '-' => match self.peekable_char_stream.peek() {
                     Some('0'..='9') => self.number(),
                     Some('.') => self.number(),
@@ -277,10 +285,7 @@ impl<CharIter: Iterator<Item = char>> Lexer<CharIter> {
                     '.' => self.dot_subsequent(&mut identifier_str)?,
                     _ => (),
                 }
-                match identifier_str.as_str() {
-                    "." => Ok(Some(TokenData::Period)),
-                    _ => Ok(Some(TokenData::Identifier(identifier_str))),
-                }
+                Ok(Some(TokenData::Identifier(identifier_str)))
             }
             None => Ok(None),
         }
@@ -509,6 +514,11 @@ fn identifier() -> Result<()> {
         ]
     );
 
+    Ok(())
+}
+
+fn period() -> Result<()> {
+    assert_eq!(tokenize(".")?, vec![TokenData::Period]);
     Ok(())
 }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -6,6 +6,7 @@ use std::io::Write;
 use rustyline::error::ReadlineError;
 use rustyline::Editor;
 
+
 fn check_bracket_closed(chars: impl Iterator<Item = char>) -> bool {
     let mut count = 0;
     let mut in_comment = false;


### PR DESCRIPTION
This PR implements pairs and list operations, and also fix the quotation problem. Now a quoted list is seen as a list literal, which will eval to a scheme object (aka interpreter::Value).  Other quoted expressions are also literals of it's corresponding types,  distinguished by it's formals. 

Pairs can be constructed via `(cons a b)` or `'(a . b)`. Proper list can be constructed via  `'(a b)` or `'(a  b . ())`

Data, aka scheme objects. aka Value, can be treated as program, and consumed by upcoming feature `eval`

Some buildin procedures are not implement,  except `car` `cdr` `pair?` and `cons` . Procedures like `list?` can be implement in scheme, we will soon append it.