### PR TITLE
Refactor some buildin procedures, wrap Vector in Rc, new buildin procedures

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -554,6 +554,9 @@ impl<R: RealNumberInternalTrait, E: IEnvironment<R>> Value<R, E> {
     pub fn expect_vector(self) -> Result<ValueReference<Vec<Value<R, E>>>> {
         match_expect_type!(self, Value::Vector(vector) => vector, "vector")
     }
+    pub fn expect_list_or_pair(self) -> Result<Pair<R, E>> {
+        match_expect_type!(self, Value::Pair(list) => *list, "list/pair")
+    }
 }
 
 impl<R: RealNumberInternalTrait, E: IEnvironment<R>> fmt::Display for Value<R, E> {
@@ -1531,7 +1534,9 @@ fn datum_literal() -> Result<()> {
             ))))),
             &interpreter.env,
         )?,
-        Value::Vector(vec![Value::Number(Number::Integer(1))])
+        Value::Vector(ValueReference::new_immutable(vec![Value::Number(
+            Number::Integer(1)
+        )]))
     );
     Ok(())
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -3,6 +3,7 @@ use crate::environment::*;
 use crate::error::*;
 use crate::lexer::*;
 use crate::parser::*;
+use cell::{RefCell, RefMut};
 use itertools::join;
 use num_traits::real::Real;
 use pair::Pair;
@@ -11,7 +12,7 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::iter::Iterator;
 use std::marker::PhantomData;
-use std::rc::Rc;
+use std::{ops::Deref, rc::Rc};
 
 type Result<T> = std::result::Result<T, SchemeError>;
 
@@ -457,6 +458,29 @@ impl<R: RealNumberInternalTrait, E: IEnvironment<R>> fmt::Display for Procedure<
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum Object<T> {
+    Immutable(T),
+    Mutable(Rc<RefCell<T>>),
+}
+
+impl<T> Object<T> {
+    pub fn new_mutable(t: T) -> Self {
+        Self::Mutable(Rc::new(RefCell::new(t)))
+    }
+    pub fn as_ref<'a>(&'a self) -> Box<dyn 'a + Deref<Target = T>> {
+        match self {
+            Object::Immutable(t) => Box::new(t),
+            Object::Mutable(t) => Box::new(t.borrow()),
+        }
+    }
+    pub fn as_mut<'a>(&'a self) -> Option<RefMut<'a, T>> {
+        match self {
+            Object::Immutable(_) => None,
+            Object::Mutable(t) => Some(t.borrow_mut()),
+        }
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
 pub enum Value<R: RealNumberInternalTrait, E: IEnvironment<R>> {
     Number(Number<R>),
     Boolean(bool),
@@ -464,7 +488,7 @@ pub enum Value<R: RealNumberInternalTrait, E: IEnvironment<R>> {
     String(String),
     Symbol(String),
     Procedure(Procedure<R, E>),
-    Vector(Vec<Value<R, E>>),
+    Vector(Object<Vec<Value<R, E>>>),
     Pair(Box<Pair<R, E>>),
     EmptyList,
     Void,
@@ -481,9 +505,11 @@ impl<R: RealNumberInternalTrait, E: IEnvironment<R>> fmt::Display for Value<R, E
             Value::Boolean(false) => write!(f, "#f"),
             Value::Character(c) => write!(f, "#\\{}", c),
             Value::String(ref s) => write!(f, "\"{}\"", s),
-            Value::Vector(vec) => {
-                write!(f, "#({})", join(vec.iter().map(|v| format!("{}", v)), " "))
-            }
+            Value::Vector(vec) => write!(
+                f,
+                "#({})",
+                join(vec.as_ref().iter().map(|v| format!("{}", v)), " ")
+            ),
             Value::Pair(list) => write!(f, "{}", list),
             Value::EmptyList => write!(f, "()"),
         }
@@ -683,11 +709,11 @@ impl<R: RealNumberInternalTrait, E: IEnvironment<R>> Interpreter<R, E> {
                         .collect::<Result<_>>()?),
                 }
             }
-            ExpressionBody::Vector(vec) => Ok(Value::Vector(
+            ExpressionBody::Vector(vec) => Ok(Value::Vector(Object::Immutable(
                 vec.iter()
                     .map(|i| Self::read_literal(i, env))
                     .collect::<Result<_>>()?,
-            )),
+            ))),
             ExpressionBody::Quote(inner) => Ok(vec![
                 Self::read_literal(inner, env)?,
                 Value::Symbol("quote".to_string()),

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -458,29 +458,32 @@ impl<R: RealNumberInternalTrait, E: IEnvironment<R>> fmt::Display for Procedure<
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum Object<T> {
-    Immutable(T),
+pub enum ValueReference<T> {
+    Immutable(Rc<T>),
     Mutable(Rc<RefCell<T>>),
 }
 
-impl<T> Object<T> {
+impl<T> ValueReference<T> {
+    pub fn new_immutable(t: T) -> Self {
+        Self::Immutable(Rc::new(t))
+    }
     pub fn new_mutable(t: T) -> Self {
         Self::Mutable(Rc::new(RefCell::new(t)))
     }
     pub fn as_ref<'a>(&'a self) -> Box<dyn 'a + Deref<Target = T>> {
         match self {
-            Object::Immutable(t) => Box::new(t),
-            Object::Mutable(t) => Box::new(t.borrow()),
+            ValueReference::Immutable(t) => Box::new(t.as_ref()),
+            ValueReference::Mutable(t) => Box::new(t.borrow()),
         }
     }
     pub fn as_mut<'a>(&'a self) -> Result<RefMut<'a, T>> {
         match self {
-            Object::Immutable(_) => Err(SchemeError {
+            ValueReference::Immutable(_) => Err(SchemeError {
                 location: None,
                 category: ErrorType::Logic,
-                message: "expect a mutable object, get a immutable object!".to_string(),
+                message: "expect a mutable reference, get a immutable reference!".to_string(),
             }),
-            Object::Mutable(t) => Ok(t.borrow_mut()),
+            ValueReference::Mutable(t) => Ok(t.borrow_mut()),
         }
     }
 }
@@ -533,7 +536,7 @@ pub enum Value<R: RealNumberInternalTrait, E: IEnvironment<R>> {
     String(String),
     Symbol(String),
     Procedure(Procedure<R, E>),
-    Vector(Object<Vec<Value<R, E>>>),
+    Vector(ValueReference<Vec<Value<R, E>>>),
     Pair(Box<Pair<R, E>>),
     EmptyList,
     Void,
@@ -548,7 +551,7 @@ impl<R: RealNumberInternalTrait, E: IEnvironment<R>> Value<R, E> {
         match_expect_type!(self, Value::Number(Number::Integer(i)) => i, "integer")
     }
 
-    pub fn expect_vector(self) -> Result<Object<Vec<Value<R, E>>>> {
+    pub fn expect_vector(self) -> Result<ValueReference<Vec<Value<R, E>>>> {
         match_expect_type!(self, Value::Vector(vector) => vector, "vector")
     }
 }
@@ -768,7 +771,7 @@ impl<R: RealNumberInternalTrait, E: IEnvironment<R>> Interpreter<R, E> {
                         .collect::<Result<_>>()?),
                 }
             }
-            ExpressionBody::Vector(vec) => Ok(Value::Vector(Object::Immutable(
+            ExpressionBody::Vector(vec) => Ok(Value::Vector(ValueReference::new_immutable(
                 vec.iter()
                     .map(|i| Self::read_literal(i, env))
                     .collect::<Result<_>>()?,

--- a/src/interpreter/scheme/base.rs
+++ b/src/interpreter/scheme/base.rs
@@ -316,6 +316,40 @@ fn buildin_make_vector() {
     }
 }
 
+fn vector_length<R: RealNumberInternalTrait, E: IEnvironment<R>>(
+    arguments: impl IntoIterator<Item = Value<R, E>>,
+) -> Result<Value<R, E>> {
+    let vector = arguments.into_iter().next().unwrap().expect_vector()?;
+    let len = vector.as_ref().len();
+    Ok(Value::Number(Number::Integer(len as i32)))
+}
+
+#[test]
+fn buildin_vector_length() {
+    {
+        let vector: Value<f32, StandardEnv<_>> =
+            Value::Vector(ValueReference::new_immutable(vec![
+                Value::Number(Number::Integer(5)),
+                Value::String("foo".to_string()),
+                Value::Number(Number::Rational(5, 3)),
+            ]));
+        let arguments = vec![vector.clone()];
+        assert_eq!(
+            vector_length(arguments),
+            Ok(Value::Number(Number::Integer(3)))
+        );
+    }
+    {
+        let vector: Value<f32, StandardEnv<_>> =
+            Value::Vector(ValueReference::new_immutable(vec![]));
+        let arguments = vec![vector.clone()];
+        assert_eq!(
+            vector_length(arguments),
+            Ok(Value::Number(Number::Integer(0)))
+        );
+    }
+}
+
 fn vector_ref<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
@@ -657,6 +691,12 @@ pub fn base_library<'a, R: RealNumberInternalTrait, E: IEnvironment<R>>(
             vec!["k".to_string(), "obj".to_string()],
             None,
             make_vector
+        ),
+        function_mapping!(
+            "vector-length",
+            vec!["vector".to_string()],
+            None,
+            vector_length
         ),
         function_mapping!(
             "vector-ref",

--- a/src/interpreter/scheme/base.rs
+++ b/src/interpreter/scheme/base.rs
@@ -7,20 +7,14 @@ fn car<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let mut iter = arguments.into_iter();
-    match iter.next() {
-        Some(Value::Pair(list)) => Ok(list.car.clone()),
-        _ => logic_error!("car target is not a list/pair"),
-    }
+    Ok(iter.next().unwrap().expect_list_or_pair()?.car)
 }
 
 fn cdr<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let mut iter = arguments.into_iter();
-    match iter.next() {
-        Some(Value::Pair(list)) => Ok(list.cdr.clone()),
-        _ => logic_error!("cdr target is not a list/pair"),
-    }
+    Ok(iter.next().unwrap().expect_list_or_pair()?.cdr)
 }
 
 fn cons<R: RealNumberInternalTrait, E: IEnvironment<R>>(

--- a/src/interpreter/scheme/base.rs
+++ b/src/interpreter/scheme/base.rs
@@ -48,70 +48,168 @@ fn add<R: RealNumberInternalTrait, E: IEnvironment<R>>(
 ) -> Result<Value<R, E>> {
     arguments
         .into_iter()
-        .try_fold(Value::Number(Number::Integer(0)), |a, b| match (a, b) {
-            (Value::Number(num1), Value::Number(num2)) => Ok(Value::Number(num1 + num2)),
-            o => logic_error!("expect a number, got {}", o.1),
-        })
+        .try_fold(Number::Integer(0), |a, b| Ok(a + b.expect_number()?))
+        .map(|num| Value::Number(num))
+}
+
+#[test]
+fn buildin_add() {
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![];
+        assert_eq!(add(arguments), Ok(Value::Number(Number::Integer(0))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![Value::Number(Number::Integer(2))];
+        assert_eq!(add(arguments), Ok(Value::Number(Number::Integer(2))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(3)),
+        ];
+        assert_eq!(add(arguments), Ok(Value::Number(Number::Integer(5))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(3)),
+            Value::Number(Number::Integer(4)),
+        ];
+        assert_eq!(add(arguments), Ok(Value::Number(Number::Integer(9))));
+    }
 }
 
 fn sub<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let mut iter = arguments.into_iter();
-    let init = match iter.next().unwrap() {
-        Value::Number(first_num) => match iter.next() {
-            Some(second) => match second {
-                Value::Number(second_num) => Value::Number(first_num - second_num),
-                o => logic_error!("expect a number, got {}", o),
-            },
-            None => Value::Number(Number::Integer(0) - first_num),
-        },
-        o => logic_error!("expect a number, got {}", o),
+    let first = iter.next().unwrap().expect_number()?;
+    let init = match iter.next() {
+        Some(value) => first - value.expect_number()?,
+        None => Number::Integer(0) - first,
     };
-    iter.try_fold(init, |a, b| match (a, b) {
-        (Value::Number(num1), Value::Number(num2)) => Ok(Value::Number(num1 - num2)),
-        o => logic_error!("expect a number, got {}", o.1),
-    })
+    iter.try_fold(init, |a, b| Ok(a - b.expect_number()?))
+        .map(|num| Value::Number(num))
+}
+
+#[test]
+fn buildin_sub() {
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![Value::Number(Number::Integer(2))];
+        assert_eq!(sub(arguments), Ok(Value::Number(Number::Integer(-2))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(3)),
+        ];
+        assert_eq!(sub(arguments), Ok(Value::Number(Number::Integer(-1))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(3)),
+            Value::Number(Number::Integer(4)),
+        ];
+        assert_eq!(sub(arguments), Ok(Value::Number(Number::Integer(-5))));
+    }
 }
 
 fn mul<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
-    let mut iter = arguments.into_iter();
-    iter.try_fold(Value::Number(Number::Integer(1)), |a, b| match (a, b) {
-        (Value::Number(num1), Value::Number(num2)) => Ok(Value::Number(num1 * num2)),
-        o => logic_error!("expect a number, got {}", o.1),
-    })
+    arguments
+        .into_iter()
+        .try_fold(Number::Integer(1), |a, b| Ok(a * b.expect_number()?))
+        .map(|num| Value::Number(num))
+}
+
+#[test]
+fn buildin_mul() {
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![];
+        assert_eq!(mul(arguments), Ok(Value::Number(Number::Integer(1))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![Value::Number(Number::Integer(2))];
+        assert_eq!(mul(arguments), Ok(Value::Number(Number::Integer(2))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(3)),
+        ];
+        assert_eq!(mul(arguments), Ok(Value::Number(Number::Integer(6))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(3)),
+            Value::Number(Number::Integer(4)),
+        ];
+        assert_eq!(mul(arguments), Ok(Value::Number(Number::Integer(24))));
+    }
 }
 
 fn div<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let mut iter = arguments.into_iter();
-    let init = match iter.next().unwrap() {
-        Value::Number(first_num) => match iter.next() {
-            Some(second) => match second {
-                Value::Number(second_num) => Value::Number((first_num / second_num)?),
-                o => logic_error!("expect a number, got {}", o),
-            },
-            None => Value::Number((Number::Integer(1) / first_num)?),
-        },
-        o => logic_error!("expect a number, got {}", o),
+    let first = iter.next().unwrap().expect_number()?;
+    let init = match iter.next() {
+        Some(value) => (first / value.expect_number()?)?,
+        None => (Number::Integer(1) / first)?,
     };
-    iter.try_fold(init, |a, b| match (a, b) {
-        (Value::Number(num1), Value::Number(num2)) => Ok(Value::Number((num1 / num2)?)),
-        o => logic_error!("expect a number, got {}", o.1),
-    })
+    iter.try_fold(init, |a, b| Ok((a / b.expect_number()?)?))
+        .map(|num| Value::Number(num))
 }
+
+#[test]
+fn buildin_div() {
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![Value::Number(Number::Integer(2))];
+        assert_eq!(div(arguments), Ok(Value::Number(Number::Real(0.5))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(8)),
+        ];
+        assert_eq!(div(arguments), Ok(Value::Number(Number::Real(0.25))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(8)),
+            Value::Number(Number::Real(0.125)),
+        ];
+        assert_eq!(
+            div(arguments),
+            Ok(Value::<f32, _>::Number(Number::Real(2.)))
+        );
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(0)),
+        ];
+        assert_eq!(
+            div(arguments),
+            Err(SchemeError {
+                location: None,
+                category: ErrorType::Logic,
+                message: "division by exact zero".to_string(),
+            })
+        );
+    }
+}
+
 macro_rules! numeric_one_argument {
     ($name:tt, $func:tt$(, $err_handle:tt)?) => {
         fn $func<R: RealNumberInternalTrait, E: IEnvironment<R>>(
             arguments: impl IntoIterator<Item = Value<R, E>>,
         ) -> Result<Value<R, E>> {
-            match arguments.into_iter().next().unwrap() {
-                Value::Number(number) => Ok(Value::Number(number.$func()$($err_handle)?)),
-                other => logic_error!("{} requires a number, got {:?}", $name, other),
-            }
+            Ok(Value::Number(arguments.into_iter().next().unwrap().expect_number()?.$func()$($err_handle)?))
         }
     };
 }
@@ -129,17 +227,6 @@ fn buildin_numeric_one() {
             vec![Value::Number(Number::Rational(-49, 3))];
         assert_eq!(floor(arguments), Ok(Value::Number(Number::Integer(-17))));
     }
-    {
-        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![Value::String("foo".to_string())];
-        assert_eq!(
-            sqrt(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "sqrt requires a number, got String(\"foo\")".to_string(),
-            })
-        );
-    }
 }
 
 macro_rules! numeric_two_arguments {
@@ -148,14 +235,8 @@ macro_rules! numeric_two_arguments {
             arguments: impl IntoIterator<Item = Value<R, E>>,
         ) -> Result<Value<R, E>> {
             let mut iter = arguments.into_iter();
-            let lhs = match iter.next().unwrap() {
-                Value::Number(number) => number,
-                _ => logic_error!("expect a number!"),
-            };
-            let rhs = match iter.next().unwrap() {
-                Value::Number(number) => number,
-                _ => logic_error!("expect a number!"),
-            };
+            let lhs = iter.next().unwrap().expect_number()?;
+            let rhs = iter.next().unwrap().expect_number()?;
             Ok(Value::Number(lhs.$func(rhs)$($err_handle)?))
         }
     };
@@ -176,20 +257,6 @@ fn buildin_numeric_two() {
             Ok(Value::Number(Number::Integer(2)))
         );
     }
-    {
-        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
-            Value::String("foo".to_string()),
-            Value::String("bar".to_string()),
-        ];
-        assert_eq!(
-            floor_quotient(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "expect a number!".to_string(),
-            })
-        );
-    }
 }
 fn vector<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
@@ -202,16 +269,13 @@ fn vector_ref<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let mut iter = arguments.into_iter();
-    match iter.next().unwrap() {
-        Value::Vector(vector) => match iter.next().unwrap() {
-            Value::Number(Number::Integer(i)) => match vector.as_ref().get(i as usize) {
-                Some(value) => Ok(value.clone()),
-                None => logic_error!("vector index out of bound"),
-            },
-            _ => logic_error!("expect a integer!"),
-        },
-        _ => logic_error!("expect a vector!"),
-    }
+    let vector = iter.next().unwrap().expect_vector()?;
+    let k = iter.next().unwrap().expect_integer()?;
+    let r = match vector.as_ref().get(k as usize) {
+        Some(value) => Ok(value.clone()),
+        None => logic_error!("vector index out of bound"),
+    };
+    r
 }
 
 #[test]
@@ -247,57 +311,24 @@ fn buildin_vector_ref() {
             })
         );
     }
-    {
-        let arguments = vec![vector.clone(), Value::Number(Number::Real(1.5))];
-        assert_eq!(
-            vector_ref(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "expect a integer!".to_string(),
-            })
-        );
-    }
-    {
-        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
-            Value::Number(Number::Integer(1)),
-            Value::Number(Number::Integer(1)),
-        ];
-        assert_eq!(
-            vector_ref(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "expect a vector!".to_string(),
-            })
-        );
-    }
 }
 
 fn vector_set<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let mut iter = arguments.into_iter();
-    let vector = match iter.next().unwrap() {
-        Value::Vector(vector) => vector,
-        _ => logic_error!("expect a vector!"),
-    };
-    let k = match iter.next().unwrap() {
-        Value::Number(Number::Integer(i)) => i,
-        _ => logic_error!("expect a integer!"),
-    };
+    let vector = iter.next().unwrap().expect_vector()?;
+    let k = iter.next().unwrap().expect_integer()?;
     let obj = iter.next().unwrap();
-    match vector.as_mut() {
-        None => logic_error!("expect a mutable vector, get a immutable vector!"),
-        Some(mut vector) => match vector.get_mut(k as usize) {
-            None => logic_error!("vector index out of bound"),
-            Some(value) => {
-                *value = obj;
-            }
-        },
+    match vector.as_mut()?.get_mut(k as usize) {
+        None => logic_error!("vector index out of bound"),
+        Some(value) => {
+            *value = obj;
+        }
     }
     Ok(Value::Void)
 }
+
 #[test]
 fn buildin_vector_set() -> Result<()> {
     let vector: Value<f32, StandardEnv<_>> = Value::Vector(Object::new_mutable(vec![
@@ -368,36 +399,6 @@ fn buildin_vector_set() -> Result<()> {
             })
         );
     }
-    {
-        let arguments = vec![
-            vector.clone(),
-            Value::Number(Number::Rational(31, 5)),
-            Value::Number(Number::Integer(5)),
-        ];
-        assert_eq!(
-            vector_set(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "expect a integer!".to_string(),
-            })
-        );
-    }
-    {
-        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
-            Value::Number(Number::Integer(1)),
-            Value::Number(Number::Integer(1)),
-            Value::Number(Number::Integer(5)),
-        ];
-        assert_eq!(
-            vector_set(arguments),
-            Err(SchemeError {
-                location: None,
-                category: ErrorType::Logic,
-                message: "expect a vector!".to_string(),
-            })
-        );
-    }
     Ok(())
 }
 
@@ -424,20 +425,16 @@ macro_rules! comparision {
             match iter.next() {
                 None => Ok(Value::Boolean(true)),
                 Some(first) => {
-                            let mut last = first;
-                            for current in iter {
-                                match (last, current) {
-                                    (Value::Number(a), Value::Number(b)) => {
-                                        if !(a $operator b) {
-                                            return Ok(Value::Boolean(false));
-                                        }
-                                        last = Value::Number(b);
-                                    }
-                                    _ => logic_error!("{} comparision can only between numbers!", stringify!($operator)),
-                                }
-                            }
-                            Ok(Value::Boolean(true))
+                    let mut last_num = first.expect_number()?;
+                    for current in iter {
+                        let current_num = current.expect_number()?;
+                        if !(last_num $operator current_num) {
+                            return Ok(Value::Boolean(false));
                         }
+                        last_num = current_num;
+                    }
+                    Ok(Value::Boolean(true))
+                }
 
             }
         }
@@ -450,32 +447,104 @@ comparision!(greater_equal, >=);
 comparision!(less, <);
 comparision!(less_equal, <=);
 
+#[test]
+fn buildin_greater() {
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![];
+        assert_eq!(greater(arguments), Ok(Value::Boolean(true)));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![Value::Number(Number::Integer(2))];
+        assert_eq!(greater(arguments), Ok(Value::Boolean(true)));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(4)),
+            Value::Number(Number::Integer(2)),
+        ];
+        assert_eq!(greater(arguments), Ok(Value::Boolean(true)));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(4)),
+            Value::Number(Number::Integer(8)),
+        ];
+        assert_eq!(greater(arguments), Ok(Value::Boolean(false)));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(4)),
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(1)),
+        ];
+        assert_eq!(greater(arguments), Ok(Value::Boolean(true)));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(4)),
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(2)),
+        ];
+        assert_eq!(greater(arguments), Ok(Value::Boolean(false)));
+    }
+}
+
 macro_rules! first_of_order {
     ($name:tt, $cmp:tt) => {
         fn $name<R: RealNumberInternalTrait, E: IEnvironment<R>>(
                         arguments: impl IntoIterator<Item = Value<R, E>>
         ) -> Result<Value<R, E>> {
             let mut iter = arguments.into_iter();
-            match iter.next().unwrap() {
-                Value::Number(num) => {
-                    iter.try_fold(Value::Number(num), |a, b| match (a, b) {
-                        (Value::Number(num1), Value::Number(num2)) => {
-                            Ok(Value::Number(match num1 $cmp num2 {
-                                true => upcast_oprands((num1, num2)).lhs(),
-                                false => upcast_oprands((num1, num2)).rhs(),
-                            }))
-                        }
-                        o => logic_error!("expect a number, got {}", o.1),
-                    })
-                },
-                o => logic_error!("expect a number, got {}", o),
-                }
+            let init = iter.next().unwrap().expect_number()?;
+            iter.try_fold(init, |a, b_value| {
+                let b = b_value.expect_number()?;
+                let oprand = upcast_oprands((a, b));
+                Ok(if a $cmp b {oprand.lhs()} else {oprand.rhs()})
+            }).map(|num| Value::Number(num))
             }
         }
 }
 
 first_of_order!(max, >);
 first_of_order!(min, <);
+
+#[test]
+fn buildin_min() {
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![Value::Number(Number::Integer(2))];
+        assert_eq!(min(arguments), Ok(Value::Number(Number::Integer(2))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(4)),
+            Value::Number(Number::Integer(2)),
+        ];
+        assert_eq!(min(arguments), Ok(Value::Number(Number::Integer(2))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(4)),
+            Value::Number(Number::Integer(8)),
+        ];
+        assert_eq!(min(arguments), Ok(Value::Number(Number::Integer(4))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(4)),
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(1)),
+        ];
+        assert_eq!(min(arguments), Ok(Value::Number(Number::Integer(1))));
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(4)),
+            Value::Number(Number::Integer(2)),
+            Value::Number(Number::Integer(2)),
+        ];
+        assert_eq!(greater(arguments), Ok(Value::Boolean(false)));
+    }
+}
 
 pub fn base_library<'a, R: RealNumberInternalTrait, E: IEnvironment<R>>(
 ) -> HashMap<String, Value<R, E>> {

--- a/src/interpreter/scheme/base.rs
+++ b/src/interpreter/scheme/base.rs
@@ -262,7 +262,7 @@ fn vector<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let vector: Vec<Value<R, E>> = arguments.into_iter().collect();
-    Ok(Value::Vector(Object::new_mutable(vector)))
+    Ok(Value::Vector(ValueReference::new_mutable(vector)))
 }
 
 fn vector_ref<R: RealNumberInternalTrait, E: IEnvironment<R>>(
@@ -280,7 +280,7 @@ fn vector_ref<R: RealNumberInternalTrait, E: IEnvironment<R>>(
 
 #[test]
 fn buildin_vector_ref() {
-    let vector: Value<f32, StandardEnv<_>> = Value::Vector(Object::Immutable(vec![
+    let vector: Value<f32, StandardEnv<_>> = Value::Vector(ValueReference::new_immutable(vec![
         Value::Number(Number::Integer(5)),
         Value::String("foo".to_string()),
         Value::Number(Number::Rational(5, 3)),
@@ -331,7 +331,7 @@ fn vector_set<R: RealNumberInternalTrait, E: IEnvironment<R>>(
 
 #[test]
 fn buildin_vector_set() -> Result<()> {
-    let vector: Value<f32, StandardEnv<_>> = Value::Vector(Object::new_mutable(vec![
+    let vector: Value<f32, StandardEnv<_>> = Value::Vector(ValueReference::new_mutable(vec![
         Value::Number(Number::Integer(5)),
         Value::String("foo".to_string()),
         Value::Number(Number::Rational(5, 3)),
@@ -345,7 +345,7 @@ fn buildin_vector_set() -> Result<()> {
         assert_eq!(vector_set(arguments), Ok(Value::Void));
         assert_eq!(
             vector,
-            Value::Vector(Object::new_mutable(vec![
+            Value::Vector(ValueReference::new_mutable(vec![
                 Value::Number(Number::Real(3.14)),
                 Value::String("foo".to_string()),
                 Value::Number(Number::Rational(5, 3)),
@@ -361,7 +361,7 @@ fn buildin_vector_set() -> Result<()> {
         assert_eq!(vector_set(arguments), Ok(Value::Void));
         assert_eq!(
             vector,
-            Value::Vector(Object::new_mutable(vec![
+            Value::Vector(ValueReference::new_mutable(vec![
                 Value::Number(Number::Real(3.14)),
                 Value::Number(Number::Integer(5)),
                 Value::Number(Number::Rational(5, 3)),
@@ -377,7 +377,7 @@ fn buildin_vector_set() -> Result<()> {
         assert_eq!(vector_set(arguments), Ok(Value::Void));
         assert_eq!(
             vector,
-            Value::Vector(Object::new_mutable(vec![
+            Value::Vector(ValueReference::new_mutable(vec![
                 Value::Number(Number::Real(3.14)),
                 Value::Number(Number::Integer(5)),
                 Value::String("bar".to_string()),

--- a/src/interpreter/scheme/base.rs
+++ b/src/interpreter/scheme/base.rs
@@ -237,7 +237,7 @@ fn vector<R: RealNumberInternalTrait, E: IEnvironment<R>>(
     arguments: impl IntoIterator<Item = Value<R, E>>,
 ) -> Result<Value<R, E>> {
     let vector: Vec<Value<R, E>> = arguments.into_iter().collect();
-    Ok(Value::Vector(vector))
+    Ok(Value::Vector(Object::new_mutable(vector)))
 }
 
 fn vector_ref<R: RealNumberInternalTrait, E: IEnvironment<R>>(
@@ -248,6 +248,7 @@ fn vector_ref<R: RealNumberInternalTrait, E: IEnvironment<R>>(
         None => logic_error!("vector-ref requires exactly two argument"),
         Some(Value::Vector(vector)) => match iter.next() {
             None => logic_error!("vector-ref requires exactly two argument"),
+            Some(Value::Number(Number::Integer(i))) => match vector.as_ref().get(i as usize) {
                 Some(value) => Ok(value.clone()),
                 None => logic_error!("vector index out of bound"),
             },
@@ -259,11 +260,11 @@ fn vector_ref<R: RealNumberInternalTrait, E: IEnvironment<R>>(
 
 #[test]
 fn buildin_vector_ref() {
-    let vector: Value<f32, StandardEnv<_>> = Value::Vector(vec![
+    let vector: Value<f32, StandardEnv<_>> = Value::Vector(Object::Immutable(vec![
         Value::Number(Number::Integer(5)),
         Value::String("foo".to_string()),
         Value::Number(Number::Rational(5, 3)),
-    ]);
+    ]));
     {
         let arguments = vec![vector.clone(), Value::Number(Number::Integer(0))];
         assert_eq!(vector_ref(arguments), Ok(Value::Number(Number::Integer(5))));
@@ -337,6 +338,172 @@ fn buildin_vector_ref() {
             })
         );
     }
+}
+
+fn vector_set<R: RealNumberInternalTrait, E: IEnvironment<R>>(
+    arguments: impl IntoIterator<Item = Value<R, E>>,
+) -> Result<Value<R, E>> {
+    let mut iter = arguments.into_iter();
+    let vector = match iter.next() {
+        None => logic_error!("vector-set! requires exactly three argument"),
+        Some(Value::Vector(vector)) => vector,
+        _ => logic_error!("expect a vector!"),
+    };
+    let k = match iter.next() {
+        None => logic_error!("vector-set! requires exactly three argument"),
+        Some(Value::Number(Number::Integer(i))) => i,
+        _ => logic_error!("expect a integer!"),
+    };
+    let obj = match iter.next() {
+        None => logic_error!("vector-set! requires exactly three argument"),
+        Some(value) => value,
+    };
+    match vector.as_mut() {
+        None => logic_error!("expect a mutable vector, get a immutable vector!"),
+        Some(mut vector) => match vector.get_mut(k as usize) {
+            None => logic_error!("vector index out of bound"),
+            Some(value) => {
+                *value = obj;
+            }
+        },
+    }
+    Ok(Value::Void)
+}
+#[test]
+fn buildin_vector_set() -> Result<()> {
+    let vector: Value<f32, StandardEnv<_>> = Value::Vector(Object::new_mutable(vec![
+        Value::Number(Number::Integer(5)),
+        Value::String("foo".to_string()),
+        Value::Number(Number::Rational(5, 3)),
+    ]));
+    {
+        let arguments = vec![
+            vector.clone(),
+            Value::Number(Number::Integer(0)),
+            Value::Number(Number::Real(3.14)),
+        ];
+        assert_eq!(vector_set(arguments), Ok(Value::Void));
+        assert_eq!(
+            vector,
+            Value::Vector(Object::new_mutable(vec![
+                Value::Number(Number::Real(3.14)),
+                Value::String("foo".to_string()),
+                Value::Number(Number::Rational(5, 3)),
+            ]))
+        );
+    }
+    {
+        let arguments = vec![
+            vector.clone(),
+            Value::Number(Number::Integer(1)),
+            Value::Number(Number::Integer(5)),
+        ];
+        assert_eq!(vector_set(arguments), Ok(Value::Void));
+        assert_eq!(
+            vector,
+            Value::Vector(Object::new_mutable(vec![
+                Value::Number(Number::Real(3.14)),
+                Value::Number(Number::Integer(5)),
+                Value::Number(Number::Rational(5, 3)),
+            ]))
+        );
+    }
+    {
+        let arguments = vec![
+            vector.clone(),
+            Value::Number(Number::Integer(2)),
+            Value::String("bar".to_string()),
+        ];
+        assert_eq!(vector_set(arguments), Ok(Value::Void));
+        assert_eq!(
+            vector,
+            Value::Vector(Object::new_mutable(vec![
+                Value::Number(Number::Real(3.14)),
+                Value::Number(Number::Integer(5)),
+                Value::String("bar".to_string()),
+            ]))
+        );
+    }
+    {
+        let arguments = vec![
+            vector.clone(),
+            Value::Number(Number::Integer(3)),
+            Value::Number(Number::Integer(5)),
+        ];
+        assert_eq!(
+            vector_set(arguments),
+            Err(SchemeError {
+                location: None,
+                category: ErrorType::Logic,
+                message: "vector index out of bound".to_string(),
+            })
+        );
+    }
+    {
+        let arguments = vec![
+            vector.clone(),
+            Value::Number(Number::Rational(31, 5)),
+            Value::Number(Number::Integer(5)),
+        ];
+        assert_eq!(
+            vector_set(arguments),
+            Err(SchemeError {
+                location: None,
+                category: ErrorType::Logic,
+                message: "expect a integer!".to_string(),
+            })
+        );
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![
+            Value::Number(Number::Integer(1)),
+            Value::Number(Number::Integer(1)),
+            Value::Number(Number::Integer(5)),
+        ];
+        assert_eq!(
+            vector_set(arguments),
+            Err(SchemeError {
+                location: None,
+                category: ErrorType::Logic,
+                message: "expect a vector!".to_string(),
+            })
+        );
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![];
+        assert_eq!(
+            vector_set(arguments),
+            Err(SchemeError {
+                location: None,
+                category: ErrorType::Logic,
+                message: "vector-set! requires exactly three argument".to_string(),
+            })
+        );
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> = vec![vector.clone()];
+        assert_eq!(
+            vector_set(arguments),
+            Err(SchemeError {
+                location: None,
+                category: ErrorType::Logic,
+                message: "vector-set! requires exactly three argument".to_string(),
+            })
+        );
+    }
+    {
+        let arguments: Vec<Value<f32, StandardEnv<_>>> =
+            vec![vector, Value::Number(Number::Integer(1))];
+        assert_eq!(
+            vector_set(arguments),
+            Err(SchemeError {
+                location: None,
+                category: ErrorType::Logic,
+                message: "vector-set! requires exactly three argument".to_string(),
+            })
+        );
+    }
+    Ok(())
 }
 
 fn display<R: RealNumberInternalTrait, E: IEnvironment<R>>(
@@ -480,12 +647,18 @@ pub fn base_library<'a, R: RealNumberInternalTrait, E: IEnvironment<R>>(
         ),
         function_mapping!("display", vec!["value".to_string()], None, display),
         function_mapping!("newline", vec![], None, newline),
-        function_mapping!("vector", vec![], None, vector),
+        function_mapping!("vector", vec![], Some("x".to_string()), vector),
         function_mapping!(
             "vector-ref",
             vec!["vector".to_string(), "k".to_string()],
             None,
             vector_ref
+        ),
+        function_mapping!(
+            "vector-set!",
+            vec!["vector".to_string(), "k".to_string(), "obj".to_string()],
+            None,
+            vector_set
         ),
     ]
     .into_iter()

--- a/src/interpreter/scheme/base.rs
+++ b/src/interpreter/scheme/base.rs
@@ -245,10 +245,9 @@ fn vector_ref<R: RealNumberInternalTrait, E: IEnvironment<R>>(
 ) -> Result<Value<R, E>> {
     let mut iter = arguments.into_iter();
     match iter.next() {
-        None => logic_error!("vector_ref requires exactly two argument"),
+        None => logic_error!("vector-ref requires exactly two argument"),
         Some(Value::Vector(vector)) => match iter.next() {
-            None => logic_error!("vector_ref requires exactly two argument"),
-            Some(Value::Number(Number::Integer(i))) => match vector.get(i as usize) {
+            None => logic_error!("vector-ref requires exactly two argument"),
                 Some(value) => Ok(value.clone()),
                 None => logic_error!("vector index out of bound"),
             },
@@ -323,7 +322,7 @@ fn buildin_vector_ref() {
             Err(SchemeError {
                 location: None,
                 category: ErrorType::Logic,
-                message: "vector_ref requires exactly two argument".to_string(),
+                message: "vector-ref requires exactly two argument".to_string(),
             })
         );
     }
@@ -334,7 +333,7 @@ fn buildin_vector_ref() {
             Err(SchemeError {
                 location: None,
                 category: ErrorType::Logic,
-                message: "vector_ref requires exactly two argument".to_string(),
+                message: "vector-ref requires exactly two argument".to_string(),
             })
         );
     }


### PR DESCRIPTION
* Use Value::expect_xxx to get the expect type of value, simplify the buildin library code
* Add unit test for add, sub, mul, div, greater and min
* Refactor Value::Vector to avoid clone, intro mutability
* New buildin procedure vector-set!, vector-length and make-vector
