### PR TITLE
feat: add a new fn new_lib for IEnvironment

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -30,6 +30,13 @@ pub trait IEnvironment<R: RealNumberInternalTrait>: std::fmt::Debug + Clone + Pa
     fn new_child(parent: Rc<Self>) -> Self
     where
         Self: Sized;
+
+    fn new_lib(_root: Rc<Self>) -> Self
+    where
+        Self: Sized,
+    {
+        Self::new()
+    }
     /// iterate all local definitions in environment
     /// # Example
     /// ```

--- a/src/interpreter/interpreter.rs
+++ b/src/interpreter/interpreter.rs
@@ -558,7 +558,7 @@ impl<R: RealNumberInternalTrait, E: IEnvironment<R>> Interpreter<R, E> {
         let name = library_definition.0.clone();
         let mut definitions = HashMap::new();
         let mut final_exports = Vec::new();
-        let lib_env = Rc::new(E::new());
+        let lib_env = Rc::new(E::new_lib(self.env.clone()));
         for declaration in &library_definition.1 {
             match &declaration.data {
                 LibraryDeclaration::ImportDeclaration(imports) => {


### PR DESCRIPTION
Env::new_lib is equal to Env::new for most of time
some scheme extension will override it, when it need to share some global state between root env and library env