### PR TITLE
#97 Add explicit newlines

### DIFF
--- a/src/repl.rs
+++ b/src/repl.rs
@@ -61,6 +61,9 @@ pub fn run_with_interpreter(mut it: Interpreter<f32>) {
                     rl.add_history_entry(source.clone());
                     source.clear();
                 }
+				else {
+					source.push('\n');
+				}
             }
             Err(ReadlineError::Interrupted) => {
                 source.clear();


### PR DESCRIPTION
Add explicit newlines at the end of unterminated sexps in the REPL.

Fixes #97.